### PR TITLE
Merge develop to main

### DIFF
--- a/apps/pihole/deployment.yaml
+++ b/apps/pihole/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pihole
+  labels:
+    app: pihole
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: pihole
+  template:
+    metadata:
+      labels:
+        app: pihole
+    spec:
+      containers:
+        - name: pihole
+          image: pihole/pihole:2025.11.1
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: dns-tcp
+              containerPort: 53
+              protocol: TCP
+            - name: dns-udp
+              containerPort: 53
+              protocol: UDP
+          env:
+            - name: TZ
+              value: Europe/Amsterdam
+            - name: WEBPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pihole-password
+                  key: WEBPASSWORD
+          volumeMounts:
+            - name: pihole-data
+              mountPath: /etc/pihole
+              subPath: pihole
+            - name: pihole-data
+              mountPath: /etc/dnsmasq.d
+              subPath: dnsmasq
+          livenessProbe:
+            tcpSocket:
+              port: 53
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 53
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: pihole-data
+          persistentVolumeClaim:
+            claimName: pihole-data

--- a/apps/pihole/kustomization.yaml
+++ b/apps/pihole/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pihole
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/pihole/namespace.yaml
+++ b/apps/pihole/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pihole

--- a/apps/pihole/pvc.yaml
+++ b/apps/pihole/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pihole-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/pihole/secret.yaml.template
+++ b/apps/pihole/secret.yaml.template
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole-password
+type: Opaque
+stringData:
+  WEBPASSWORD: change-me

--- a/apps/pihole/service.yaml
+++ b/apps/pihole/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole
+  labels:
+    app: pihole
+spec:
+  type: LoadBalancer
+  selector:
+    app: pihole
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+    - name: dns-tcp
+      port: 53
+      targetPort: dns-tcp
+      protocol: TCP
+    - name: dns-udp
+      port: 53
+      targetPort: dns-udp
+      protocol: UDP

--- a/docs/pihole.md
+++ b/docs/pihole.md
@@ -1,0 +1,55 @@
+# Pi-hole
+
+## Configure
+
+Update the web password before deploy (private repo):
+
+```bash
+cp apps/pihole/secret.yaml.template overlays/homelab/pihole/secret.yaml
+kubectl -n pihole create secret generic pihole-password --from-literal=WEBPASSWORD='your-strong-password' --dry-run=client -o yaml > overlays/homelab/pihole/secret.yaml
+```
+
+## Deploy
+
+```bash
+kubectl apply -k overlays/sample/pihole
+```
+
+Private repo:
+
+```bash
+kubectl apply -k overlays/homelab/pihole
+```
+
+## Deco DNS settings
+
+Set the primary DNS in the Deco app to the Pi-hole LoadBalancer IP:
+
+```bash
+kubectl -n pihole get svc pihole -o jsonpath="{.status.loadBalancer.ingress[0].ip}"
+```
+
+## Argo CD application
+
+Apply the Argo CD stack to register Pi-hole in Argo CD (private repo):
+
+```bash
+kubectl apply -k argocd
+```
+
+## Cloudflare tunnel access
+
+Create a Public Hostname in your existing Cloudflare Tunnel:
+
+- Subdomain: `pihole`
+- Domain: `your-domain`
+- Type: `HTTP`
+- URL: `pihole.pihole.svc.cluster.local:80`
+
+If you set the origin to HTTPS on port 80, Cloudflare will attempt a TLS
+handshake against a plain HTTP endpoint and fail with a TLS error. Use HTTP
+on port 80, or HTTPS on port 443 with No TLS Verify enabled.
+
+Pi-hole serves the UI under `/admin`, so open:
+
+- `https://pihole.your-domain/admin/`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a complete Pi-hole Kubernetes app.
> 
> - Adds `Deployment` with `pihole/pihole:2025.11.1`, TCP/UDP DNS and HTTP ports, liveness/readiness probes on `53`, `TZ`/`WEBPASSWORD` env (via `Secret`), and PVC-backed mounts for `pihole` and `dnsmasq`
> - Creates `Service` (LoadBalancer) exposing `80`, `53/TCP`, and `53/UDP`
> - Adds `PersistentVolumeClaim` (5Gi), `Namespace`, `kustomization.yaml`, and `secret.yaml.template`
> - Documents configuration and deployment steps, including Deco DNS settings, Argo CD registration, and Cloudflare Tunnel access
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 788373a954bb07daaf87e9d53a1d10ec4ee465b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->